### PR TITLE
Fix event handling

### DIFF
--- a/classes/converter.php
+++ b/classes/converter.php
@@ -360,7 +360,7 @@ class converter implements \core_files\converter_interface {
                 'id' => $conversion->get('id'),
                 'status' => $this->status
             ));
-        $event = \fileconverter_librelambda\event\poll_conversion_status::create($eventinfo);
+        $event = \fileconverter_librelambda\event\start_document_conversion::create($eventinfo);
         $event->trigger();
 
         return $this;

--- a/classes/converter.php
+++ b/classes/converter.php
@@ -358,7 +358,6 @@ class converter implements \core_files\converter_interface {
                 'key' => $file->get_pathnamehash(),
                 'targetformat' => $conversion->get('targetformat'),
                 'id' => $conversion->get('id'),
-                'sourcefileid' => $conversion->get('sourcefileid'),
                 'status' => $this->status
             ));
         $event = \fileconverter_librelambda\event\poll_conversion_status::create($eventinfo);
@@ -420,7 +419,6 @@ class converter implements \core_files\converter_interface {
                 'key' => $file->get_pathnamehash(),
                 'targetformat' => $conversion->get('targetformat'),
                 'id' => $conversion->get('id'),
-                'sourcefileid' => $conversion->get('sourcefileid'),
                 'status' => $this->status
             ));
         $event = \fileconverter_librelambda\event\poll_conversion_status::create($eventinfo);


### PR DESCRIPTION
I discovered some minor issues with the events logging the status of document conversion. Specifically

- In each of the two cases there was a redundant line. They can be safely deleted.
- There are two event classes, but only one was used. I actually like the distinction, so I would use both.

Also, on that note, thanks for this plugin. The code quality is great, so it is helping me as a blueprint for creating my own document converter at the moment. Actually I am able to copy a lot of the original code (with proper attribution, of course :) ). Thank you, @mattporritt :) !