### PR TITLE
Fix to use correct DEBUG_ const causing unit test to fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://github.com/catalyst/moodle-fileconverter_librelambda/workflows/Run%20all%20tests%20for%20Moodle%2034+/badge.svg)](https://github.com/catalyst/moodle-fileconverter_librelambda/actions)
+![GitHub Workflow Status (branch)](https://img.shields.io/github/actions/workflow/status/catalyst/moodle-fileconverter_librelambda/ci.yml?branch=master)
 
 # Libre Lambda Document Converter #
 

--- a/classes/converter.php
+++ b/classes/converter.php
@@ -282,7 +282,7 @@ class converter implements \core_files\converter_interface {
         $converter = new \fileconverter_librelambda\converter();
         // First check that we have the basic configuration settings set.
         if (!$converter->is_config_set()) {
-            debugging(get_string('settings:confignotset', 'fileconverter_librelambda'), 'notifyproblem');
+            debugging(get_string('settings:confignotset', 'fileconverter_librelambda'), DEBUG_NORMAL);
             return false;
         }
         $converter->create_client();

--- a/classes/event/poll_conversion_status.php
+++ b/classes/event/poll_conversion_status.php
@@ -33,16 +33,25 @@ namespace fileconverter_librelambda\event;
  */
 class poll_conversion_status extends \core\event\base {
 
+    /**
+     * Init function.
+     */
     protected function init() {
         $this->data['crud'] = 'c';
         $this->data['edulevel'] = self::LEVEL_PARTICIPATING;
 
     }
 
+    /**
+     * Get event name.
+     */
     public static function get_name() {
         return get_string('event:poll_conversion_status', 'fileconverter_librelambda');
     }
 
+    /**
+     * Get event description.
+     */
     public function get_description() {
         return "The conversion with id '{$this->other['id']}' has been polled and returned the status '{$this->other['status']}'.";
     }

--- a/classes/event/start_document_conversion.php
+++ b/classes/event/start_document_conversion.php
@@ -33,16 +33,25 @@ namespace fileconverter_librelambda\event;
  */
 class start_document_conversion extends \core\event\base {
 
+    /**
+     * Init function.
+     */
     protected function init() {
         $this->data['crud'] = 'c';
         $this->data['edulevel'] = self::LEVEL_PARTICIPATING;
 
     }
 
+    /**
+     * Get event name.
+     */
     public static function get_name() {
         return get_string('event:start_document_conversion', 'fileconverter_librelambda');
     }
 
+    /**
+     * Get event description.
+     */
     public function get_description() {
         return "The conversion with id '{$this->other['id']}' has been commenced with status '{$this->other['status']}'.";
     }

--- a/classes/provision.php
+++ b/classes/provision.php
@@ -41,7 +41,10 @@ use Aws\Exception\AwsException;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class provision {
+    /** The default stack name */
     const DEFAULT_STACK_NAME = 'LambdaConvert';
+
+    /** The max bucket prefix length */
     const MAX_BUCKET_PREFIX_LEN = 52;
 
     /**

--- a/cli/get_files.php
+++ b/cli/get_files.php
@@ -15,7 +15,9 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * This command line script will get all document files from S3 in a site that
+ * The command line script.
+ *
+ * Will get all document files from S3 in a site that
  * uses the object fs plugin and download them locally
  *
  * @package     fileconverter_librelambda

--- a/cli/provision.php
+++ b/cli/provision.php
@@ -66,7 +66,10 @@ If you want to replace the stack use \"--replace-stack\" option
 ";
 $stacknotexistsmsg = "Stack does not exsist.";
 
-function abort($msg) {
+/** Abort function
+ * @param string $msg
+ */
+function abort(string $msg) {
     echo "$msg\n";
     die;
 }

--- a/tests/converter_test.php
+++ b/tests/converter_test.php
@@ -22,6 +22,9 @@
  * @copyright   2018 Matt Porritt <mattp@catalyst-au.net>
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
+namespace fileconverter_librelambda;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -33,6 +36,8 @@ use Aws\CommandInterface;
 use Psr\Http\Message\RequestInterface;
 use Aws\S3\Exception\S3Exception;
 use \core_files\conversion;
+use \context_module;
+use \ReflectionMethod;
 
 /**
  * PHPUnit tests for Libre Lambda file converter.
@@ -41,7 +46,7 @@ use \core_files\conversion;
  * @copyright   2018 Matt Porritt <mattp@catalyst-au.net>
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class fileconverter_librelambda_converter_testcase extends advanced_testcase {
+class converter_test extends \advanced_testcase {
 
     /**
      * Test is_config_set method with missing configuration.

--- a/tests/events_test.php
+++ b/tests/events_test.php
@@ -22,6 +22,9 @@
  * @copyright   2018 Matt Porritt <mattp@catalyst-au.net>
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
+namespace fileconverter_librelambda;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -33,6 +36,7 @@ use Aws\CommandInterface;
 use Psr\Http\Message\RequestInterface;
 use Aws\S3\Exception\S3Exception;
 use \core_files\conversion;
+use \context_module;
 
 /**
  * PHPUnit tests for Libre Lambda file converter.
@@ -41,7 +45,7 @@ use \core_files\conversion;
  * @copyright   2018 Matt Porritt <mattp@catalyst-au.net>
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class fileconverter_librelambda_events_testcase extends advanced_testcase {
+class events_test extends \advanced_testcase {
 
     /**
      * Test start document conversion method.

--- a/tests/provision_test.php
+++ b/tests/provision_test.php
@@ -22,13 +22,16 @@
  * @copyright   2018 Matt Porritt <mattp@catalyst-au.net>
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
+namespace fileconverter_librelambda;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot . '/local/aws/sdk/aws-autoloader.php');
 
-use Aws\Result;
 use Aws\MockHandler;
+use Aws\Result;
 use Aws\CommandInterface;
 use Psr\Http\Message\RequestInterface;
 use Aws\S3\Exception\S3Exception;
@@ -41,7 +44,7 @@ use Aws\CloudFormation\Exception\CloudFormationException;
  * @copyright   2018 Matt Porritt <mattp@catalyst-au.net>
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class mock_provision extends \fileconverter_librelambda\provision {
+class provision_mock extends provision {
     /**
      *
      * @var MockHandler
@@ -100,13 +103,13 @@ class mock_provision extends \fileconverter_librelambda\provision {
      * Create an S3 Bucket in AWS.
      * Upgrade to public.
      *
-     * @param string $bucketname The name to use for the S3 bucket.
      * @return \stdClass $result The result of the bucket creation.
      */
     public function create_resource_bucket() {
         return parent::create_resource_bucket();
     }
 }
+
 
 /**
  * PHPUnit tests for Libre Lambda AWS provision.
@@ -115,14 +118,14 @@ class mock_provision extends \fileconverter_librelambda\provision {
  * @copyright   2018 Matt Porritt <mattp@catalyst-au.net>
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class fileconverter_librelambda_provision_testcase extends advanced_testcase {
+class provision_test extends \advanced_testcase {
 
     /**
      * Test the does bucket exist method. Should return false.
      * We mock out the S3 client response as we are not trying to connect to the live AWS API.
      */
     public function test_create_resource_bucket_exists_false() {
-        $provisioner = new mock_provision();
+        $provisioner = new provision_mock();
 
         $provisioner->mocks3handler->append(function (CommandInterface $cmd, RequestInterface $req) {
             return new S3Exception('Mock exception', $cmd, ['code' => 'NotFound']);
@@ -144,7 +147,7 @@ class fileconverter_librelambda_provision_testcase extends advanced_testcase {
      * We mock out the S3 client response as we are not trying to connect to the live AWS API.
      */
     public function test_create_resource_bucket_exists_true() {
-        $provisioner = new mock_provision();
+        $provisioner = new provision_mock();
 
         $provisioner->mocks3handler->append(new Result([]));
 
@@ -161,7 +164,7 @@ class fileconverter_librelambda_provision_testcase extends advanced_testcase {
      * We mock out the S3 client response as we are not trying to connect to the live AWS API.
      */
     public function test_create_resource_bucket_exists_forbidden() {
-        $provisioner = new mock_provision();
+        $provisioner = new provision_mock();
 
         $bucketname = 'foobar';
         $provisioner->mocks3handler->append(function (CommandInterface $cmd, RequestInterface $req) {
@@ -179,7 +182,7 @@ class fileconverter_librelambda_provision_testcase extends advanced_testcase {
     public function test_provision_stack_exists_no_replace() {
         global $CFG;
 
-        $provisioner = new mock_provision();
+        $provisioner = new provision_mock();
 
         $provisioner->mocks3handler->append(new Result([]));
         $provisioner->mocks3handler->append(new Result(['ObjectURL' => "https://amazon/lambdaconvert.zip"]));
@@ -212,7 +215,7 @@ class fileconverter_librelambda_provision_testcase extends advanced_testcase {
         global $CFG;
 
         $lambdazip = 'lambdaconvert.zip';
-        $provisioner = new mock_provision();
+        $provisioner = new provision_mock();
 
         $provisioner->mocks3handler->append(new Result([]));
         $provisioner->mocks3handler->append(new Result(['ObjectURL' => "https://amazon/$lambdazip"]));
@@ -268,7 +271,7 @@ class fileconverter_librelambda_provision_testcase extends advanced_testcase {
 
         $stack = 'AnotherStack';
         $lambdazip = 'lambdaconvert.zip';
-        $provisioner = new mock_provision($stack);
+        $provisioner = new provision_mock($stack);
 
         $provisioner->mocks3handler->append(new Result([]));
         $provisioner->mocks3handler->append(new Result(['ObjectURL' => "https://amazon/$lambdazip"]));
@@ -323,7 +326,7 @@ class fileconverter_librelambda_provision_testcase extends advanced_testcase {
         global $CFG;
 
         $filename = 'some.file';
-        $provisioner = new mock_provision();
+        $provisioner = new provision_mock();
 
         $cloudformationpath = $CFG->dirroot . '/files/converter/librelambda/lambda/stack.template';
         $provisioner->mockcloudformationhandler->append(new Result([

--- a/version.php
+++ b/version.php
@@ -25,11 +25,11 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'fileconverter_librelambda';
-$plugin->release = 2022011500;
-$plugin->version = 2022011500;
+$plugin->release = 2023010900;
+$plugin->version = 2023010900;
 $plugin->requires = 2017111309;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = array(
-        'local_aws' => 2020061500
+    'local_aws' => 2022033100
 );
-$plugin->supported = [34, 311]; // A range of branch numbers of supported moodle versions.
+$plugin->supported = [34, 401]; // A range of branch numbers of supported moodle versions.


### PR DESCRIPTION
Fixes #66

```
There was 1 failure:

1) fileconverter_librelambda_converter_testcase::test_are_requirements_met_false
Failed asserting that actual size 0 matches expected size 1.

/var/www/moodlepgsql/files/converter/librelambda/tests/converter_test.php:182
/var/www/moodlepgsql/lib/phpunit/classes/advanced_testcase.php:80
```